### PR TITLE
update org.activiti.cloud.dependencies:activiti-cloud-modeling-dependencies to 7.0.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </distributionManagement>
   <properties>
     <activiti-cloud.version>7.0.96</activiti-cloud.version>
-    <activiti-cloud-modeling.version>7.0.3</activiti-cloud-modeling.version>
+    <activiti-cloud-modeling.version>7.0.25</activiti-cloud-modeling.version>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <enforcer.skip>true</enforcer.skip>
     <java.version>1.8</java.version>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.cloud.dependencies:activiti-cloud-modeling-dependencies` to: `7.0.21`