### PR TITLE
Check visibility of task variables is fixed

### DIFF
--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/task-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/task-actions.story
@@ -110,6 +110,8 @@ And task variable start1 has value start1modified
 And the user claims the task
 And the user completes the task
 And another user is authenticated as hruser
+And a task variable was created with name start1
+And a task variable was created with name start2
 Then task variable start1 has value start1
 
 Scenario: check the task is updated


### PR DESCRIPTION
The addition of the [previously removed two steps](https://github.com/Activiti/Activiti/issues/2144) to the scenario is green.
