### PR TITLE
update org.activiti.cloud.dependencies:activiti-cloud-modeling-dependencies to 7.0.61

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   </distributionManagement>
   <properties>
     <activiti-cloud.version>7.0.187</activiti-cloud.version>
-    <activiti-cloud-modeling.version>7.0.60</activiti-cloud-modeling.version>
+    <activiti-cloud-modeling.version>7.0.61</activiti-cloud-modeling.version>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <enforcer.skip>true</enforcer.skip>
     <java.version>11</java.version>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.cloud.dependencies:activiti-cloud-modeling-dependencies` to: `7.0.61`