### PR TITLE
update org.activiti.cloud.dependencies:activiti-cloud-dependencies to 7.1.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     </snapshotRepository>
   </distributionManagement>
   <properties>
-    <activiti-cloud-dependencies.version>7.1.19</activiti-cloud-dependencies.version>
+    <activiti-cloud-dependencies.version>7.1.20</activiti-cloud-dependencies.version>
     <activiti-cloud-modeling.version>7.1.19</activiti-cloud-modeling.version>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <enforcer.skip>true</enforcer.skip>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.cloud.dependencies:activiti-cloud-dependencies` to: `7.1.20`