### PR TITLE
Fix check process definition version on task

### DIFF
--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/Tasks.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/Tasks.java
@@ -37,6 +37,7 @@ import org.activiti.cloud.acc.core.steps.runtime.ProcessRuntimeBundleSteps;
 import org.activiti.cloud.acc.core.steps.runtime.TaskRuntimeBundleSteps;
 import org.activiti.cloud.acc.core.steps.runtime.admin.ProcessRuntimeAdminSteps;
 import org.activiti.cloud.acc.core.steps.runtime.admin.TaskRuntimeAdminSteps;
+import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.qa.helpers.VariableGenerator;
 import org.jbehave.core.annotations.Given;
@@ -147,14 +148,18 @@ public class Tasks {
         assertThat(subtasks.iterator().next()).extracting("id").containsOnly(subtask.getId());
     }
 
-    @Then("the tasks has the formKey field")
-    public void checkIfFormKeyIsPresent(){
+    @Then("the task has the formKey field and correct processInstance fields")
+    public void checkIfFormKeyAndProcessInstanceFiledsArePresent(){
         newTask = obtainFirstTaskFromProcess();
         assertThat(newTask).extracting("formKey").contains("taskForm");
 
+        CloudProcessInstance processFromQuery = processQuerySteps.getProcessInstance(Serenity.sessionVariableCalled("processInstanceId").toString());
+        assertThat(processFromQuery).isNotNull();
         CloudTask taskFromQuery = taskRuntimeBundleSteps.getTaskById(newTask.getId());
         assertThat(taskFromQuery).isNotNull();
         assertThat(taskFromQuery.getFormKey()).isEqualTo("taskForm");
+        assertThat(taskFromQuery.getProcessDefinitionId()).isEqualTo(processFromQuery.getProcessDefinitionId());
+        assertThat(taskFromQuery.getProcessDefinitionVersion()).isEqualTo(processFromQuery.getProcessDefinitionVersion());
     }
 
     private CloudTask obtainFirstTaskFromProcess() {

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/Tasks.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/Tasks.java
@@ -149,13 +149,18 @@ public class Tasks {
     }
 
     @Then("the task has the formKey field and correct processInstance fields")
-    public void checkIfFormKeyAndProcessInstanceFiledsArePresent(){
+    public void checkIfFormKeyAndProcessInstanceFieldsArePresent(){
         newTask = obtainFirstTaskFromProcess();
         assertThat(newTask).extracting("formKey").contains("taskForm");
 
         CloudProcessInstance processFromQuery = processQuerySteps.getProcessInstance(Serenity.sessionVariableCalled("processInstanceId").toString());
         assertThat(processFromQuery).isNotNull();
-        CloudTask taskFromQuery = taskRuntimeBundleSteps.getTaskById(newTask.getId());
+        CloudTask taskFromRB = taskRuntimeBundleSteps.getTaskById(newTask.getId());
+        assertThat(taskFromRB).isNotNull();
+        assertThat(taskFromRB.getFormKey()).isEqualTo("taskForm");
+        assertThat(taskFromRB.getProcessDefinitionId()).isEqualTo(processFromQuery.getProcessDefinitionId());
+        
+        CloudTask taskFromQuery = taskQuerySteps.getTaskById(newTask.getId());
         assertThat(taskFromQuery).isNotNull();
         assertThat(taskFromQuery.getFormKey()).isEqualTo("taskForm");
         assertThat(taskFromQuery.getProcessDefinitionId()).isEqualTo(processFromQuery.getProcessDefinitionId());

--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/task-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/task-actions.story
@@ -97,7 +97,7 @@ Then the task from SUB_PROCESS_INSTANCE_WITH_TASK is CREATED and it is called su
 Scenario: check the presence of formKey field in task
 Given the user is authenticated as testuser
 When the user starts an instance of the process called PROCESS_INSTANCE_WITH_SINGLE_TASK_ASSIGNED
-Then the tasks has the formKey field
+Then the task has the formKey field and correct processInstance fields
 
 Scenario: tasks have their own copies of variables
 Given the user is authenticated as testuser


### PR DESCRIPTION
Field only available in query service (not in rb)
Related to https://github.com/Activiti/Activiti/issues/2644