### PR TITLE
fix: missing variable for Start a process containing cloud connector

### DIFF
--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceConnectors.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceConnectors.java
@@ -47,14 +47,14 @@ public class ProcessInstanceConnectors {
 
     private CloudProcessInstance processInstance;
 
-    @Given("the user provides a variable named $variableName with value $variableValue")
+    @Given("the user provides a variable named $variableName with string value $variableValue")
     public void givenVariable(String variableName,
                               String variableValue) {
         variableBufferSteps.addVariable(variableName,
                                         variableValue);
     }
 
-    @Given("the user provides an integer variable named $variableName with value $variableValue")
+    @Given("the user provides an variable named $variableName with integer value $variableValue")
     public void givenVariable(String variableName,
                               Integer variableValue) {
         variableBufferSteps.addVariable(variableName,

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceConnectors.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceConnectors.java
@@ -16,6 +16,10 @@
 
 package org.activiti.cloud.qa.story;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
+
 import java.util.Collection;
 
 import net.thucydides.core.annotations.Steps;
@@ -29,10 +33,6 @@ import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
 import org.jbehave.core.annotations.When;
 import org.springframework.hateoas.Resources;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.awaitility.Awaitility.await;
 
 public class ProcessInstanceConnectors {
 
@@ -54,6 +54,13 @@ public class ProcessInstanceConnectors {
                                         variableValue);
     }
 
+    @Given("the user provides an integer variable named $variableName with value $variableValue")
+    public void givenVariable(String variableName,
+                              Integer variableValue) {
+        variableBufferSteps.addVariable(variableName,
+                                        variableValue);
+    }
+    
     @When("the user starts an instance of process called $processDefinitionKey with the provided variables")
     public void startProcessWithAvailableVariables(String processDefinitionKey) {
         processInstance = processRuntimeBundleSteps.startProcessWithVariables(processDefinitionKey,

--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-connectors-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-connectors-actions.story
@@ -5,8 +5,8 @@ I want to perform operations os processes containing connectors
 
 Scenario: Start a process containing cloud connector
 Given the user is authenticated as testuser
-And the user provides a variable named movieToRank with value The Lord of The Rings
-And the user provides an integer variable named rating with value 1
+And the user provides a variable named movieToRank with string value The Lord of The Rings
+And the user provides an variable named rating with integer value 1
 When the user starts an instance of process called RankMovieId with the provided variables
 Then the process instance has a variable named movieToRank with value The Lord of The Rings
 And the process instance has a variable named movieDesc with value The Lord of the Rings is an epic high fantasy novel written by English author and scholar J. R. R. Tolkien

--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-connectors-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-connectors-actions.story
@@ -6,6 +6,7 @@ I want to perform operations os processes containing connectors
 Scenario: Start a process containing cloud connector
 Given the user is authenticated as testuser
 And the user provides a variable named movieToRank with value The Lord of The Rings
+And the user provides an integer variable named rating with value 1
 When the user starts an instance of process called RankMovieId with the provided variables
 Then the process instance has a variable named movieToRank with value The Lord of The Rings
 And the process instance has a variable named movieDesc with value The Lord of the Rings is an epic high fantasy novel written by English author and scholar J. R. R. Tolkien


### PR DESCRIPTION
There is a failing connector story that starts the process with:

```
{
  "processDefinitionKey": "RankMovieId",
  "payloadType":"StartProcessPayload",
  "variables": {
      "movieToRank" : "The Lord of The Rings"
  }
}
```
That fails with the error:
```
{
    "timestamp": "2019-05-01T17:57:24.209+0000",
    "status": 500,
    "error": "Internal Server Error",
    "message": "Can't start process 'RankMovieId' as variables fail type validation - rating",
    "path": "/v1/process-instances"
}
```
Because It expects variable rating of type Integer, but there is no step that provides it in the scenario:
```
Meta:
Narrative:
As a user
I want to perform operations os processes containing connectors

Scenario: Start a process containing cloud connector
Given the user is authenticated as testuser
And the user provides a variable named movieToRank with value The Lord of The Rings
When the user starts an instance of process called RankMovieId with the provided variables
Then the process instance has a variable named movieToRank with value The Lord of The Rings
And the process instance has a variable named movieDesc with value The Lord of the Rings is an epic high fantasy novel written by English author and scholar J. R. R. Tolkien
And the process instance has a task named Add Rating
```

The fixed scenario has steps to provide variables with string and integer values:

```
Meta:
Narrative:
As a user
I want to perform operations os processes containing connectors

Scenario: Start a process containing cloud connector
Given the user is authenticated as testuser
And the user provides a variable named movieToRank with string value The Lord of The Rings
And the user provides an variable named rating with integer value 1
When the user starts an instance of process called RankMovieId with the provided variables
Then the process instance has a variable named movieToRank with value The Lord of The Rings
And the process instance has a variable named movieDesc with value The Lord of the Rings is an epic high fantasy novel written by English author and scholar J. R. R. Tolkien
And the process instance has a task named Add Rating
```
