### PR TITLE
Acceptance tests covering signal events  

### DIFF
--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceSignalEvents.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceSignalEvents.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.qa.story;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+
+import net.thucydides.core.annotations.Steps;
+import org.activiti.api.process.model.ProcessInstance;
+import org.activiti.cloud.acc.core.steps.audit.AuditSteps;
+import org.activiti.cloud.acc.core.steps.query.ProcessQuerySteps;
+import org.activiti.cloud.acc.core.steps.runtime.ProcessRuntimeBundleSteps;
+import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
+import org.activiti.cloud.api.process.model.CloudProcessInstance;
+import org.jbehave.core.annotations.Then;
+import org.jbehave.core.annotations.When;
+
+public class ProcessInstanceSignalEvents {
+
+    @Steps
+    private ProcessRuntimeBundleSteps runtimeBundleSteps;
+    
+    @Steps
+    private ProcessQuerySteps processQuerySteps;
+    
+    @Steps
+    private AuditSteps auditSteps;
+    
+    private CloudProcessInstance processInstanceCatchSignal;
+    private CloudProcessInstance processInstanceThrowSignal;
+    
+    @When("services are started")
+    public void checkServicesStatus() {
+        runtimeBundleSteps.checkServicesHealth();
+        processQuerySteps.checkServicesHealth();
+        auditSteps.checkServicesHealth();
+    }
+    
+    @When("the user starts a process with intermediate catch signal")
+    public void startSignalCatchProcessInstance() {
+        processInstanceCatchSignal = runtimeBundleSteps.startProcess("SignalCatchEventProcess");
+        assertThat(processInstanceCatchSignal).isNotNull();
+    }
+    
+    @When("the user starts a process with intermediate throw signal")
+    public void startSignalThrowProcessInstance() {
+        processInstanceThrowSignal = runtimeBundleSteps.startProcess("SignalThrowEventProcess");
+        assertThat(processInstanceThrowSignal).isNotNull();
+    }
+
+    @Then("the process throwing a signal is completed")
+    public void sheckSignalThrowProcessInstance() throws Exception {
+        processQuerySteps.checkProcessInstanceStatus(processInstanceThrowSignal.getId(),
+                                                     ProcessInstance.ProcessInstanceStatus.COMPLETED);
+    }
+    
+    @Then("the process catching a signal is completed")
+    public void sheckSignalCatchProcessInstance() throws Exception {
+        processQuerySteps.checkProcessInstanceStatus(processInstanceCatchSignal.getId(),
+                                                     ProcessInstance.ProcessInstanceStatus.COMPLETED);       
+    }
+    
+    @Then("the SIGNAL_RECEIVED event was catched up")
+    public void sheckSignalReceivedEvent() throws Exception {
+        Collection<CloudRuntimeEvent> events = auditSteps.getEventsByProcessInstanceIdAndEventType(processInstanceCatchSignal.getId(),
+                                                                                                   "SIGNAL_RECEIVED"); 
+        
+        assertThat(events).isNotEqualTo(0);        
+    }
+    
+  
+
+}

--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-signal-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-signal-actions.story
@@ -4,13 +4,19 @@ Narrative:
 As a user
 I want to perform operations on process instances with throw catch signal
 
-Scenario: process instances with throw catch signal
-Given the user is authenticated as testuser
+Scenario: process instances with throw, catch, boundary and start signal events
+Given the user is authenticated as hruser
 Then check number of processes with processDefinitionKey SignalStartEventProcess
 When the user starts a process with intermediate catch signal
-And the user starts a process with intermediate throw signal
+And the user starts a process with a boundary signal
+Then the task is created with a name Boundary container
+When the user starts a process with intermediate throw signal
 Then the process throwing a signal is completed
 And the process catching a signal is completed
-Then check number of processes with processDefinitionKey SignalStartEventProcess increased
+And check number of processes with processDefinitionKey SignalStartEventProcess increased
 And the SIGNAL_RECEIVED event was catched up by intermediateCatchEvent process
-
+And the task is created with a name Boundary target
+And the SIGNAL_RECEIVED event was catched up by boundary signal process
+When another user is authenticated as testadmin
+And the admin deletes boundary signal process
+Then boundary signal process is deleted

--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-signal-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-signal-actions.story
@@ -1,0 +1,13 @@
+Meta:
+
+Narrative:
+As a user
+I want to perform operations on process instances with throw catch signal
+
+Scenario: process instances with throw catch signal
+Given the user is authenticated as testuser
+When the user starts a process with intermediate catch signal
+And the user starts a process with intermediate throw signal
+Then the process throwing a signal is completed
+And the process catching a signal is completed
+And the SIGNAL_RECEIVED event was catched up

--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-signal-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-signal-actions.story
@@ -6,8 +6,11 @@ I want to perform operations on process instances with throw catch signal
 
 Scenario: process instances with throw catch signal
 Given the user is authenticated as testuser
+Then check number of processes with processDefinitionKey SignalStartEventProcess
 When the user starts a process with intermediate catch signal
 And the user starts a process with intermediate throw signal
 Then the process throwing a signal is completed
 And the process catching a signal is completed
-And the SIGNAL_RECEIVED event was catched up
+Then check number of processes with processDefinitionKey SignalStartEventProcess increased
+And the SIGNAL_RECEIVED event was catched up by intermediateCatchEvent process
+


### PR DESCRIPTION
Related to https://github.com/Activiti/Activiti/issues/2691
Depends on
https://github.com/Activiti/example-runtime-bundle/pull/261
https://github.com/Activiti/activiti-cloud-acceptance-tests/pull/169