### PR TITLE
feat(ProcessInstanceTasks): add query process diagram scenarios

### DIFF
--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import feign.FeignException;
 import net.serenitybdd.core.Serenity;
 import net.thucydides.core.annotations.Steps;
 import org.activiti.api.model.shared.event.VariableEvent;
@@ -89,6 +90,7 @@ public class ProcessInstanceTasks {
     private String processInstanceDiagram;
 
     private Task currentTask;
+    private String processInstanceAdminDiagram;
 
     @When("services are started")
     public void checkServicesStatus() {
@@ -326,6 +328,45 @@ public class ProcessInstanceTasks {
         processRuntimeBundleSteps.checkProcessInstanceNoDiagram(processInstanceDiagram);
     }
 
+    @When("query the process diagram")
+    public void queryProcessInstanceDiagram() {
+        processInstanceDiagram = processQuerySteps.getProcessInstanceDiagram(processInstance.getId());
+    }
+
+    @When("query the process diagram admin endpoint")
+    public void queryProcessInstanceDiagramAdmin() {
+        processInstanceAdminDiagram = processQueryAdminSteps.getProcessInstanceDiagram(processInstance.getId());
+    }
+    
+    @When("query the process diagram admin endpoint is unauthorized")
+    public void queryProcessInstanceDiagramAdminUnauthorized() {
+        try {
+            processInstanceAdminDiagram = processQueryAdminSteps.getProcessInstanceDiagram(processInstance.getId());
+        } catch (FeignException expected) {
+            assertThat(expected.status()).isEqualTo(403);
+        }
+    }    
+
+    @Then("the query diagram is shown in admin endpoint")
+    public void checkQueryProcessInstanceDiagramAdmin() throws Exception {
+        processQueryAdminSteps.checkProcessInstanceDiagram(processInstanceAdminDiagram);
+    }
+
+    @Then("no query diagram is shown in admin endpoint")
+    public void checkQueryProcessInstanceNoDiagramAdmin() throws Exception {
+        processQueryAdminSteps.checkProcessInstanceNoDiagram(processInstanceAdminDiagram);
+    }
+    
+    @Then("the query diagram is shown")
+    public void checkQueryProcessInstanceDiagram() throws Exception {
+        processQuerySteps.checkProcessInstanceDiagram(processInstanceDiagram);
+    }
+
+    @Then("no query diagram is shown")
+    public void checkQueryProcessInstanceNoDiagram() throws Exception {
+        processQuerySteps.checkProcessInstanceNoDiagram(processInstanceDiagram);
+    }
+    
     @When("activate the process")
     public void activateCurrentProcessInstance() {
         processRuntimeBundleSteps.resumeProcessInstance(processInstance.getId());

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
@@ -344,7 +344,10 @@ public class ProcessInstanceTasks {
             processInstanceAdminDiagram = processQueryAdminSteps.getProcessInstanceDiagram(processInstance.getId());
         } catch (FeignException expected) {
             assertThat(expected.status()).isEqualTo(403);
+            return;
         }
+        
+        throw new AssertionError("fail");
     }    
 
     @Then("the query diagram is shown in admin endpoint")

--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
@@ -39,6 +39,30 @@ When the user starts an instance of the process called PROCESS_INSTANCE_WITHOUT_
 And open the process diagram
 Then no diagram is shown
 
+Scenario: query a process instance diagram
+Given the user is authenticated as testuser
+When the user starts an instance of the process called CONNECTOR_PROCESS_INSTANCE
+And query the process diagram
+Then the query diagram is shown
+
+Scenario: query diagram for a process instance without graphic info
+Given the user is authenticated as testuser
+When the user starts an instance of the process called PROCESS_INSTANCE_WITHOUT_GRAPHIC_INFO
+And query the process diagram
+Then the diagram is shown
+
+Scenario: query a process instance diagram admin endpoint as hradmin user
+Given the user is authenticated as testuser
+When the user starts an instance of the process called CONNECTOR_PROCESS_INSTANCE
+And another user is authenticated as hradmin
+And query the process diagram admin endpoint
+Then the query diagram is shown in admin endpoint
+
+Scenario: query a process instance diagram admin endpoint as testuser
+Given the user is authenticated as hruser
+When the user starts an instance of the process called CONNECTOR_PROCESS_INSTANCE
+Then query the process diagram admin endpoint is unauthorized
+
 Scenario: complete a process instance that uses a connector
 Given the user is authenticated as testuser
 When the user starts a process with variables called CONNECTOR_PROCESS_INSTANCE


### PR DESCRIPTION
This PR adds query process diagram acceptance scenarios 

Part of https://github.com/Activiti/Activiti/issues/2750

Depends on https://github.com/Activiti/activiti-cloud-query-service/pull/238 and https://github.com/Activiti/activiti-cloud-acceptance-tests/pull/174