### PR TITLE
feat: add complete a process instance that sends a signal with subscription 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     </snapshotRepository>
   </distributionManagement>
   <properties>
-    <activiti-cloud-dependencies.version>7.1.84</activiti-cloud-dependencies.version>
+    <activiti-cloud-dependencies.version>7.1.85</activiti-cloud-dependencies.version>
     <activiti-cloud-modeling.version>7.1.89</activiti-cloud-modeling.version>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <enforcer.skip>true</enforcer.skip>

--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/helpers/ProcessDefinitionRegistry.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/helpers/ProcessDefinitionRegistry.java
@@ -35,6 +35,7 @@ public class ProcessDefinitionRegistry {
     private static final HashMap <String, String> processWithNoTasksDefinitionKeys = new HashMap<String, String>(){{
         put("SIMPLE_PROCESS_INSTANCE","SimpleProcess");
         put("CONNECTOR_PROCESS_INSTANCE","ConnectorProcess");
+        put("SIGNAL_THROW_PROCESS_INSTANCE","SignalThrowEventProcess");
         put("PROCESS_INSTANCE_WITH_CALL_ACTIVITIES","parentproc-8e992556-5785-4ee0-9fe7-354decfea4a8");
         put("Process Information","processinf-4e42752c-cc4d-429b-9528-7d3df24a9537");
         put("Process with Generic BPMN Task","processwit-c6fd1b26-0d64-47f2-8d04-0b70764444a7");

--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/notifications-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/notifications-actions.story
@@ -2,10 +2,16 @@ Meta:
 
 Narrative:
 As a user
-I want to perform operations on process instances
+I want to perform operations on process instances with subscriptions to receive notifications
 
-Scenario: complete a process instance that uses a connector
+Scenario: complete a process instance that uses a connector with subscription
 Given the user is authenticated as testadmin
-When the user starts a process with notifications called CONNECTOR_PROCESS_INSTANCE
+When the user starts a process CONNECTOR_PROCESS_INSTANCE with PROCESS_STARTED and PROCESS_COMPLETED events subscriptions
 Then the status of the process is completed
-Then notifications are received
+Then PROCESS_STARTED and PROCESS_COMPLETED notifications are received
+
+Scenario: complete a process instance that sends a signal with subscription 
+Given the user is authenticated as testadmin
+When the user starts a process SIGNAL_THROW_PROCESS_INSTANCE with SIGNAL_RECEIVED subscription
+Then the status of the process is completed
+And SIGNAL_RECEIVED notification with theStart signal event is received


### PR DESCRIPTION
This PR adds Notification acceptance scenario to complete a process instance that sends a signal with subscription 

Part of https://github.com/Activiti/Activiti/issues/2721

Depends on https://github.com/Activiti/activiti-cloud-notifications-service-graphql/pull/65 and https://github.com/Activiti/activiti-cloud-acceptance-tests/pull/175

