### PR TITLE
feat: add notifications acceptance scenarios for BPMN timers

### DIFF
--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/helpers/ProcessDefinitionRegistry.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/helpers/ProcessDefinitionRegistry.java
@@ -41,9 +41,16 @@ public class ProcessDefinitionRegistry {
         put("Process with Generic BPMN Task","processwit-c6fd1b26-0d64-47f2-8d04-0b70764444a7");
     }};
 
+    private static final HashMap <String, String> processWithTimerEvents = new HashMap<String, String>(){{
+        put("INTERMEDIATE_TIMER_EVENT_PROCESS","intermediateTimerEventExample");
+        put("START_TIMER_EVENT_PROCESS","startTimerEventExample");
+        put("BOUNDARY_TIMER_EVENT_PROCESS","boundaryTimerEventExample");
+    }};    
+
     public static final HashMap <String, String> processDefinitionKeys = new HashMap<String, String>(){{
         putAll(processWithTasksDefinitionKeys);
         putAll(processWithNoTasksDefinitionKeys);
+        putAll(processWithTimerEvents);
     }};
 
     public static String processDefinitionKeyMatcher (String processName){

--- a/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/notifications-actions.story
+++ b/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/notifications-actions.story
@@ -15,3 +15,15 @@ Given the user is authenticated as testadmin
 When the user starts a process SIGNAL_THROW_PROCESS_INSTANCE with SIGNAL_RECEIVED subscription
 Then the status of the process is completed
 And SIGNAL_RECEIVED notification with theStart signal event is received
+
+Scenario: complete a process instance with intermediate timer subscription 
+Given the user is authenticated as testadmin
+When the user starts a process INTERMEDIATE_TIMER_EVENT_PROCESS with TIMER subscriptions
+Then the status of the process is completed
+And TIMER notifications are received
+
+Scenario: complete a process instance with boundary timer subscription 
+Given the user is authenticated as testadmin
+When the user starts a process BOUNDARY_TIMER_EVENT_PROCESS with TIMER subscriptions
+Then the status of the process is completed
+And TIMER notifications are received


### PR DESCRIPTION
This PR adds process instance notications acceptance scenarios for BPMN timer events.

Part of https://github.com/Activiti/Activiti/issues/2636