### PR TITLE
AAE-395 Modify extensions verification message

### DIFF
--- a/modeling-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ModelingModels.java
+++ b/modeling-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ModelingModels.java
@@ -126,4 +126,9 @@ public class ModelingModels {
     public void checkCurrentModelValidationErrorsForExtensions(String numberOfErrors) throws IOException {
         modelingModelsSteps.checkCurrentModelValidationFailureForExtensions("#: " + numberOfErrors + " schema violations found");
     }
+    
+    @Then("$numberOfErrors validation schemas are matched for extensions")
+    public void checkCurrentModelValidationSchemaMatchesForExtensions(String numberOfErrors) throws IOException {
+        modelingModelsSteps.checkCurrentModelValidationFailureForExtensions("#: #: only " + numberOfErrors + " subschema matches out of 2");
+    }
 }

--- a/modeling-acceptance-tests/src/main/resources/stories/modeling/modeling-models.story
+++ b/modeling-acceptance-tests/src/main/resources/stories/modeling/modeling-models.story
@@ -49,4 +49,4 @@ And an existing project 'nasa-team'
 When the user opens the project 'nasa-team'
 And creates the process model spacex-launch with process variables 'age, gender'
 And opens the process model 'spacex-launch'
-Then 2 validation errors are shown for extensions
+Then 0 validation schemas are matched for extensions


### PR DESCRIPTION
Modify the extensions validation message when failed because now, the JSON extensions validation is done by 2 different Json Schemas, one for the common extension fields for all the models, and another for the specific model extensions.