### PR TITLE
fix(Notifications): Replaced Map.of with ObjectMap due to removed dependencies

### DIFF
--- a/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceNotifications.java
+++ b/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceNotifications.java
@@ -319,9 +319,11 @@ public class ProcessInstanceNotifications {
                         "  }" +
                         "}";
 
-        Map<String, Object> variables = Map.of("serviceName", serviceName,
-                                               "eventTypes", eventTypes,
-                                               "businessKey", businessKey);
+        Map<String, Object> variables = new ObjectMap() {{
+            put("serviceName", serviceName);
+            put("eventTypes", eventTypes);
+            put("businessKey", businessKey);
+        }};
 
         Consumer<Subscription> action = countDownLatchAction(countDownLatch, 
                                                              subscriptionRef, 


### PR DESCRIPTION
This PR fixes removal of Map.of class from dependency tree.