### PR TITLE
fix(versions): update Activiti/activiti-cloud-acceptance-scenarios versions into master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     </snapshotRepository>
   </distributionManagement>
   <properties>
-    <activiti-cloud-acceptance-tests.version>7.1.178</activiti-cloud-acceptance-tests.version>
+    <activiti-cloud-acceptance-tests.version>7.1.179</activiti-cloud-acceptance-tests.version>
     <activiti-cloud-modeling.version>7.1.373</activiti-cloud-modeling.version>
     <asm.version>7.0</asm.version>
     <awaitility.version>3.1.1</awaitility.version>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.cloud.acc:activiti-cloud-acceptance-tests-dependencies` to: `7.1.179`