### PR TITLE
fix(versions): update Activiti/activiti-cloud-acceptance-scenarios versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
     </snapshotRepository>
   </distributionManagement>
   <properties>
-    <activiti-cloud-acceptance-tests.version>7.1.426</activiti-cloud-acceptance-tests.version>
-    <activiti-cloud-modeling.version>7.1.426</activiti-cloud-modeling.version>
+    <activiti-cloud-acceptance-tests.version>7.1.427</activiti-cloud-acceptance-tests.version>
+    <activiti-cloud-modeling.version>7.1.427</activiti-cloud-modeling.version>
     <asm.version>7.0</asm.version>
     <awaitility.version>3.1.1</awaitility.version>
     <batik.version>1.10</batik.version>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.cloud.modeling:activiti-cloud-modeling-dependencies` to: `7.1.427`